### PR TITLE
Changes in function findElementsInterpolation to get Fields to interpolate in html template

### DIFF
--- a/src/redux/actions/template/index.ts
+++ b/src/redux/actions/template/index.ts
@@ -15,20 +15,18 @@ enum contractsTemplates {
 }
 
 interface contractTemplate {
-    listInterpolation: Array<String>,
+    interpolationFields: Object,
     template: String
 }
 
-const findElementsInterpolation = (html:String) : Array<String> => {
-    let listElements : Array<String> = []
+const findElementsInterpolation = (html:String) : Object => {
+    let obj : Object = {}
     let regexExp = /\{\{[a-zA-Z0-9]+\}\}/gi
     html.match(regexExp)?.forEach(element => {
         let value = element.replace(/[^a-z0-9]/gi,"")
-        if (listElements.indexOf(value) < 0){
-            listElements.push(value)
-        }
+        obj[value] = ""
     });
-    return listElements
+    return obj
 }  
 
 export const getContractTemplate = (contractName:String) :contractTemplate => {
@@ -63,7 +61,7 @@ export const getContractTemplate = (contractName:String) :contractTemplate => {
                 throw new Error("No template Found");
         }
         return {
-            listInterpolation: findElementsInterpolation(contractTemplate),
+            interpolationFields: findElementsInterpolation(contractTemplate),
             template: contractTemplate
         };
     } catch (error) {


### PR DESCRIPTION
Adding changes into function to return a Object of fields to interpolation mustache

{
"interpolationFields": {
"createDate": "",
"partyName": "",
"counterpartyName": "",
"partyAddress": "",
"partyWallet": "",
"counterPartyAddress": "",
"counterPartyWallet": ""
},
"template": "HTML"
}